### PR TITLE
Add option to round floats

### DIFF
--- a/kw/json/encode.py
+++ b/kw/json/encode.py
@@ -1,5 +1,5 @@
 import calendar
-from collections import ItemsView
+from collections import ItemsView, namedtuple
 from decimal import Decimal
 from functools import partial
 import uuid
@@ -98,11 +98,55 @@ def modify_kwargs(kwargs):
         kwargs["default"] = partial(default_encoder, date_as_unix_time=date_as_unix_time)
 
 
+def format_value(value, precision):
+    """Format provided value."""
+    if isinstance(value, float):
+        return round(value, precision)
+    if isinstance(value, (list, set)):
+        return traverse_iterable(value, precision)
+    if isinstance(value, ItemsView) or value.__class__.__name__ == "dictionary-itemiterator":
+        return traverse_dict(dict(value), precision)
+    if isinstance(value, dict):
+        return traverse_dict(value, precision)
+    if isinstance(value, tuple):
+        if getattr(value, "_fields", False):
+            # namedtuple should stay namedtuple - simplejson can format it differently
+            # depending on the `namedtuple_as_object` param
+            NewNamedtuple = namedtuple(type(value).__name__, value._asdict().keys())
+            return NewNamedtuple(**format_value(value._asdict(), precision))
+        # convert tuple to list; the tuple would be turned to list in simplejson/json anyways
+        return traverse_iterable(list(value), precision)
+    return value
+
+
+def traverse_iterable(iterable, precision):
+    """Traverse list or set and round floats."""
+    return [format_value(value, precision) for value in iterable]
+    
+
+
+def traverse_dict(obj, precision):
+    """Traverse dictionary and round floats."""
+    return {key: format_value(value, precision) for key, value in obj.items()}
+
+
+def round_floats(args, kwargs):
+    data = args[0]
+    precision = kwargs.pop("precision", False)
+    new_args = list(args)
+    if precision is not False:
+        data = format_value(data, precision)
+        new_args[0] = data
+    return new_args
+
+
 def dumps(*args, **kwargs):
+    new_args = round_floats(args, kwargs)
     modify_kwargs(kwargs)
-    return json_dumps(*args, **kwargs)
+    return json_dumps(*new_args, **kwargs)
 
 
 def dump(*args, **kwargs):
+    new_args = round_floats(args, kwargs)
     modify_kwargs(kwargs)
-    return json_dump(*args, **kwargs)
+    return json_dump(*new_args, **kwargs)


### PR DESCRIPTION
Hi, we have noticed that `ujson` implicitly rounds floats to 10 decimal places, but `simplejson` nor `json` do not do this, e.g.

```python
>>> import simplejson
>>> import ujson
>>> import json
>>> a = 69.56 - 68.
>>> a
1.5600000000000023
>>> simplejson.dumps(a)
'1.5600000000000023'
>>> json.dumps(a)
'1.5600000000000023'
>>> ujson.dumps(a)
'1.56'
```

Since we're trying to move away from `ujson` to `kw.json`, we would like it to behave the same.
In this PR, I added `precision` parameter that handles this issue and formats floats in the provided object to a number of decimal places set in `precision`.