### PR TITLE
ci(setuptools): add long_description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           bdist_wheel
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,12 @@ with open("requirements.txt") as f:
 with open("test-requirements.txt") as f:
     TEST_REQUIREMENTS = f.read().splitlines()
 
+# read the contents of your README file
+from pathlib import Path
+
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
 setup(
     name="kiwi-json",
     version="0.10.0",
@@ -16,6 +22,8 @@ setup(
     install_requires=REQUIREMENTS,
     tests_require=TEST_REQUIREMENTS,
     description="DRY JSON encoder.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Warning:  You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.
Warning:  It looks like you are trying to use an API token to authenticate in the package index and your token value does not start with "pypi-" as it typically should. This may cause an authentication error. Please verify that you have copied your token properly if such an error occurs.
Checking dist/kiwi_json-0.10.0-py3-none-any.whl: FAILED
ERROR    `long_description` has syntax errors in markup and would not be
         rendered on PyPI.
         No content rendered from RST source.
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/kiwi-json-0.10.0.tar.gz: PASSED with warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
WARNING  `long_description` missing.